### PR TITLE
Simplify Makefile to fix a link error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,4 @@
-
 all: soc_term
 
-OBJS = soc_term.o
-
-CFLAGS += -g -O0
-
-soc_term: $(OBJS)
-	gcc -o $@ $<
-
 clean:
-	rm -f $(OBJS) soc_term
+	rm -f soc_term


### PR DESCRIPTION
The Makefile uses the 'gcc' command to link the application but handles
the compilation step with the default C compiler: $(CC) which is 'cc'
by default. This can cause issues if both compilers are not the same.
For instance with 'cc' linked to clang:

 $ make
 cc -g -O0   -c -o soc_term.o soc_term.c
 [...]
 gcc -o soc_term soc_term.o
 /usr/bin/ld: soc_term.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
 collect2: error: ld returned 1 exit status
 make[1]: *** [Makefile:9: soc_term] Error 1

Remove the custom link rule so that $(CC) is used consistently.
The debug CFLAGS are also removed because they are not needed for
normal use.

Signed-off-by: Jerome Forissier <jerome@forissier.org>